### PR TITLE
Removed accented characters from seed data in WordDatabaseContext. Cr…

### DIFF
--- a/LanguagePractice/Migrations/20231002095102_RemoveAccentedCharactersFromSeedData.Designer.cs
+++ b/LanguagePractice/Migrations/20231002095102_RemoveAccentedCharactersFromSeedData.Designer.cs
@@ -3,6 +3,7 @@ using LanguagePractice.DataAccess.DataContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LanguagePracticeSite.Migrations
 {
     [DbContext(typeof(WordDatabaseContext))]
-    partial class WordDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20231002095102_RemoveAccentedCharactersFromSeedData")]
+    partial class RemoveAccentedCharactersFromSeedData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LanguagePractice/Migrations/20231002095102_RemoveAccentedCharactersFromSeedData.cs
+++ b/LanguagePractice/Migrations/20231002095102_RemoveAccentedCharactersFromSeedData.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LanguagePracticeSite.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveAccentedCharactersFromSeedData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "ImperfectWords",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "vedevamo", "vedevo", "vedevate", "vedevi", "vedevano", "vedeva" });
+
+            migrationBuilder.UpdateData(
+                table: "ImperfectWords",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "parlavamo", "parlavo", "parlare", "parlavate", "parlavi", "parlavano", "parlava" });
+
+            migrationBuilder.UpdateData(
+                table: "ImperfectWords",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "venivamo", "venivo", "venire", "venivate", "venivi", "venivano", "veniva" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentIndicativeWords",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "facciamo", "faccio", "fare", "fate", "fai", "fanno", "fa" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentIndicativeWords",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "vediamo", "vedo", "vedere", "vedete", "vedi", "vedono", "vede" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentIndicativeWords",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "parliamo", "parlo", "parlare", "parlate", "parli", "parlano", "parla" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentPerfectPhrases",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Infinitive",
+                value: "preparare");
+
+            migrationBuilder.UpdateData(
+                table: "PresentPerfectPhrases",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Infinitive",
+                value: "vendere");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "ImperfectWords",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "vedevàmo", "védevo", "vedevàte", "vedévi", "vedévano", "vedéva" });
+
+            migrationBuilder.UpdateData(
+                table: "ImperfectWords",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "parlavàmo", "parlàvo", "parlàre", "parlavàte", "parlàvi", "parlàvano", "parlàva" });
+
+            migrationBuilder.UpdateData(
+                table: "ImperfectWords",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "venivàmo", "venìvo", "venìre", "venivàte", "venìvi", "venìvano", "venìva" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentIndicativeWords",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "facciàmo", "fàccio", "fàre", "fàte", "fài", "fànno", "fà" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentIndicativeWords",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "vediàmo", "védo", "vedére", "vedéte", "védi", "védono", "véde" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentIndicativeWords",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "FirstPersonPlural", "FirstPersonSingular", "Infinitive", "SecondPersonPlural", "SecondPersonSingular", "ThirdPersonPlural", "ThirdPersonSingular" },
+                values: new object[] { "parliàmo", "pàrlo", "parlàre", "parlàte", "pàrli", "pàrlano", "pàrla" });
+
+            migrationBuilder.UpdateData(
+                table: "PresentPerfectPhrases",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Infinitive",
+                value: "preparàre");
+
+            migrationBuilder.UpdateData(
+                table: "PresentPerfectPhrases",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Infinitive",
+                value: "véndere");
+        }
+    }
+}

--- a/LanguagePractice/Models/DataContext/WordDatabaseContext.cs
+++ b/LanguagePractice/Models/DataContext/WordDatabaseContext.cs
@@ -17,21 +17,21 @@ namespace LanguagePractice.DataAccess.DataContext
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<PresentIndicative>().HasData(
-                    new PresentIndicative { Id = 1, Infinitive = "fàre", FirstPersonSingular = "fàccio", SecondPersonSingular = "fài", ThirdPersonSingular = "fà", FirstPersonPlural = "facciàmo", SecondPersonPlural = "fàte", ThirdPersonPlural = "fànno"},
-                    new PresentIndicative { Id = 2, Infinitive = "vedére", FirstPersonSingular = "védo", SecondPersonSingular = "védi", ThirdPersonSingular = "véde", FirstPersonPlural = "vediàmo", SecondPersonPlural = "vedéte", ThirdPersonPlural = "védono"},
-                    new PresentIndicative { Id = 3, Infinitive = "parlàre", FirstPersonSingular = "pàrlo", SecondPersonSingular = "pàrli", ThirdPersonSingular = "pàrla", FirstPersonPlural = "parliàmo", SecondPersonPlural = "parlàte", ThirdPersonPlural = "pàrlano"}
+                    new PresentIndicative { Id = 1, Infinitive = "fare", FirstPersonSingular = "faccio", SecondPersonSingular = "fai", ThirdPersonSingular = "fa", FirstPersonPlural = "facciamo", SecondPersonPlural = "fate", ThirdPersonPlural = "fanno"},
+                    new PresentIndicative { Id = 2, Infinitive = "vedere", FirstPersonSingular = "vedo", SecondPersonSingular = "vedi", ThirdPersonSingular = "vede", FirstPersonPlural = "vediamo", SecondPersonPlural = "vedete", ThirdPersonPlural = "vedono"},
+                    new PresentIndicative { Id = 3, Infinitive = "parlare", FirstPersonSingular = "parlo", SecondPersonSingular = "parli", ThirdPersonSingular = "parla", FirstPersonPlural = "parliamo", SecondPersonPlural = "parlate", ThirdPersonPlural = "parlano"}
                 );
 
             modelBuilder.Entity<PresentPerfect>().HasData(
-                    new PresentPerfect { Id = 1, Infinitive = "preparàre", FirstPersonSingular = "ho preparato", SecondPersonSingular = "hai preparato", ThirdPersonSingular = "ha preparato", FirstPersonPlural = "abbiamo preparato", SecondPersonPlural = "avete preparato", ThirdPersonPlural = "hanno preparato", UsesEssere = false },
-                    new PresentPerfect { Id = 2, Infinitive = "véndere", FirstPersonSingular = "ho venduto", SecondPersonSingular = "hai venduto", ThirdPersonSingular = "ha venduto", FirstPersonPlural = "abbiamo venduto", SecondPersonPlural = "avete venduto", ThirdPersonPlural = "hanno venduto", UsesEssere = false},
+                    new PresentPerfect { Id = 1, Infinitive = "preparare", FirstPersonSingular = "ho preparato", SecondPersonSingular = "hai preparato", ThirdPersonSingular = "ha preparato", FirstPersonPlural = "abbiamo preparato", SecondPersonPlural = "avete preparato", ThirdPersonPlural = "hanno preparato", UsesEssere = false },
+                    new PresentPerfect { Id = 2, Infinitive = "vendere", FirstPersonSingular = "ho venduto", SecondPersonSingular = "hai venduto", ThirdPersonSingular = "ha venduto", FirstPersonPlural = "abbiamo venduto", SecondPersonPlural = "avete venduto", ThirdPersonPlural = "hanno venduto", UsesEssere = false},
                     new PresentPerfect { Id = 3, Infinitive = "andare", FirstPersonSingular = "sono andato", SecondPersonSingular = "sei andato", ThirdPersonSingular = "è andato", FirstPersonPlural = "siamo andati", SecondPersonPlural = "siete andati", ThirdPersonPlural = "sono andati", UsesEssere = true}
                 );
 
             modelBuilder.Entity<Imperfect>().HasData(
-                    new Imperfect { Id = 1, Infinitive = "vedere", FirstPersonSingular = "védevo", SecondPersonSingular = "vedévi", ThirdPersonSingular = "vedéva", FirstPersonPlural = "vedevàmo", SecondPersonPlural = "vedevàte", ThirdPersonPlural = "vedévano"},
-                    new Imperfect { Id = 2, Infinitive = "parlàre", FirstPersonSingular = "parlàvo", SecondPersonSingular = "parlàvi", ThirdPersonSingular = "parlàva", FirstPersonPlural = "parlavàmo", SecondPersonPlural = "parlavàte", ThirdPersonPlural = "parlàvano" },
-                    new Imperfect { Id = 3, Infinitive = "venìre", FirstPersonSingular = "venìvo", SecondPersonSingular = "venìvi", ThirdPersonSingular = "venìva", FirstPersonPlural = "venivàmo", SecondPersonPlural = "venivàte", ThirdPersonPlural = "venìvano" }
+                    new Imperfect { Id = 1, Infinitive = "vedere", FirstPersonSingular = "vedevo", SecondPersonSingular = "vedevi", ThirdPersonSingular = "vedeva", FirstPersonPlural = "vedevamo", SecondPersonPlural = "vedevate", ThirdPersonPlural = "vedevano"},
+                    new Imperfect { Id = 2, Infinitive = "parlare", FirstPersonSingular = "parlavo", SecondPersonSingular = "parlavi", ThirdPersonSingular = "parlava", FirstPersonPlural = "parlavamo", SecondPersonPlural = "parlavate", ThirdPersonPlural = "parlavano" },
+                    new Imperfect { Id = 3, Infinitive = "venire", FirstPersonSingular = "venivo", SecondPersonSingular = "venivi", ThirdPersonSingular = "veniva", FirstPersonPlural = "venivamo", SecondPersonPlural = "venivate", ThirdPersonPlural = "venivano" }
                 );
         }
     }


### PR DESCRIPTION
…eate data migrations and update database to implement changes. After having discussed whether accented characters are actually used in Italian with an Italian acquaintance, I was told that accented characters are rarely used in Italian verbs and using accented characters is an archaic form of writing verbs. Accented characters are only used in certain words where there can be multiple different meanings for the same word.